### PR TITLE
fix: Update FrontendSettings type for allowed_file_extensions

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -139,6 +139,7 @@ export type FrontendSettings = {
   ui?: UI
   sanitize_answer?: boolean
   oyd_enabled?: boolean
+  allowed_file_extensions?: string;
 }
 
 export enum Feedback {


### PR DESCRIPTION
The `FrontendSettings` type in `frontend/src/api/models.ts` was missing the `allowed_file_extensions` property, which was recently added to the frontend settings fetched from the backend. This caused a TypeScript error.

This commit adds `allowed_file_extensions?: string;` to the `FrontendSettings` interface to resolve the type error.

### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
