### PR TITLE
fix: Update ChatMessage content type for file_url

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -40,7 +40,13 @@ export type AzureSqlServerExecResults = {
 export type ChatMessage = {
   id: string
   role: string
-  content: string | [{ type: string; text: string }, { type: string; image_url: { url: string } }]
+  content: string | [
+    { type: "text"; text: string },
+    (
+      | { type: "image_url"; image_url: { url: string } }
+      | { type: "file_url"; file_url: { url: string; name: string } }
+    )
+  ]
   end_turn?: boolean
   date: string
   feedback?: Feedback


### PR DESCRIPTION
The `ChatMessage.content` type definition in `frontend/src/api/models.ts` was expecting the second part of a multi-part message to always be of type `image_url`. This caused a TypeScript error when attempting to send other file types using the `file_url` structure.

This commit updates the `ChatMessage.content` type to allow the second part of a multi-part message to be either an `image_url` object or a `file_url` object. This makes the type definition consistent with the implemented functionality of supporting various file uploads.

### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
