### PR TITLE
fix: Correct file upload type and structure for API

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -44,7 +44,7 @@ export type ChatMessage = {
     { type: "text"; text: string },
     (
       | { type: "image_url"; image_url: { url: string } }
-      | { type: "file_url"; file_url: { url: string; name: string } }
+      | { type: "file"; file: { url: string; name: string } }
     )
   ]
   end_turn?: boolean

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -193,10 +193,10 @@ const Chat = () => {
       const secondPart = question[1];
       if (secondPart.type === "image_url") {
         questionContent = [firstPart, { type: "image_url", image_url: { url: secondPart.image_url.url } }];
-      } else if (secondPart.type === "file_url") {
-        questionContent = [firstPart, { type: "file_url", file_url: { url: secondPart.file_url.url, name: secondPart.file_url.name } }];
+      } else if (secondPart.type === "file") {
+        questionContent = [firstPart, { type: "file", file: { url: (secondPart as any).file.url, name: (secondPart as any).file.name } }];
       } else {
-        // Fallback or error handling if needed, though current types restrict to image_url or file_url
+        // Fallback or error handling if needed, though current types restrict to image_url or file
         questionContent = firstPart.text; 
       }
     }
@@ -335,8 +335,8 @@ const Chat = () => {
       const secondPart = question[1];
       if (secondPart.type === "image_url") {
         questionContentWithFile = [firstPart, { type: "image_url", image_url: { url: secondPart.image_url.url } }];
-      } else if (secondPart.type === "file_url") {
-        questionContentWithFile = [firstPart, { type: "file_url", file_url: { url: secondPart.file_url.url, name: secondPart.file_url.name } }];
+      } else if (secondPart.type === "file") {
+        questionContentWithFile = [firstPart, { type: "file", file: { url: (secondPart as any).file.url, name: (secondPart as any).file.name } }];
       } else {
         // Fallback or error handling if needed
         questionContentWithFile = firstPart.text;
@@ -845,9 +845,9 @@ const Chat = () => {
                                   alt="Uploaded Preview"
                                 />
                               )}
-                              {answer.content[1].type === "file_url" && (
+                              {answer.content[1].type === "file" && (
                                 <div className={styles.uploadedFileChat}>
-                                  Attached file: {answer.content[1].file_url.name}
+                                  Attached file: {answer.content[1].file.name}
                                 </div>
                               )}
                             </>


### PR DESCRIPTION
This commit addresses an API error "Invalid value: 'file_url'" by changing the way non-image files are sent to the backend.

The following changes were made:

- Frontend (`QuestionInput.tsx`):
    - For non-image files, the payload now uses `type: "file"` with a nested structure: `{ file: { url: base64DataUrl, name: fileName } }`.
    - Image files continue to use `type: "image_url"`.
    - State management for `selectedFile` was refined.

- TypeScript Definitions (`models.ts`):
    - The `ChatMessage.content` type was updated to reflect the new `{ type: "file", file: { ... } }` structure, replacing the previous `file_url` definition.

- Frontend (`Chat.tsx`):
    - Updated type checks and property access to align with the new `type: "file"` and its nested `file` object for both preparing API requests and rendering message content.

These changes ensure that the payload sent to the AI backend for file uploads (that are not images) conforms to a supported type ("file") as indicated by the API error messages.

### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
