### PR TITLE
fix: Ensure consistent use of "file" type for uploads

### DIFF
--- a/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -65,7 +65,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
       return
     }
 
-    let fileContentPart: { type: "image_url"; image_url: { url: string } } | { type: "file_url"; file_url: { url: string; name: string } } | null = null;
+    let fileContentPart: { type: "image_url"; image_url: { url: string } } | { type: "file"; file: { url: string; name: string } } | null = null;
 
     if (base64File && selectedFile && fileName) { // Ensure selectedFile and fileName are also checked
       if (selectedFile.type.startsWith('image/')) {


### PR DESCRIPTION
This commit resolves TypeScript errors in `QuestionInput.tsx` that arose from inconsistencies between its declared types and the actual data structures being used for file uploads, which should conform to the `ChatMessage` type in `models.ts`.

- Corrected an explicit type annotation in `QuestionInput.tsx` for a variable holding file content parts. It was previously expecting `{ type: "file_url", ... }` but has been updated to correctly expect `{ type: "file", file: { ... } }` for generic files, aligning with the `ChatMessage` model.

This ensures that `QuestionInput.tsx`, `Chat.tsx`, and `models.ts` all consistently use the `type: "file"` and `type: "image_url"` structures as intended, resolving build-time type errors.

### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
