### PR TITLE
feat: Implement two-step file upload for Azure OpenAI Assistants

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -44,7 +44,7 @@ export type ChatMessage = {
     { type: "text"; text: string },
     (
       | { type: "image_url"; image_url: { url: string } }
-      | { type: "file"; file: { url: string; name: string } }
+      | { type: "file"; file: { file_id: string; name?: string } }
     )
   ]
   end_turn?: boolean

--- a/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -18,15 +18,25 @@ interface Props {
 
 export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conversationId }: Props) => {
   const [question, setQuestion] = useState<string>('')
-  const [base64File, setBase64File] = useState<string | null>(null);
-  const [fileName, setFileName] = useState<string | null>(null);
+  const [base64File, setBase64File] = useState<string | null>(null); // Keep for potential image previews if needed later
+  const [fileName, setFileName] = useState<string | null>(null); // For immediate UI feedback on selection
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadedFileId, setUploadedFileId] = useState<string | null>(null);
+  const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState<boolean>(false);
 
   const appStateContext = useContext(AppStateContext)
   const OYD_ENABLED = appStateContext?.state.frontendSettings?.oyd_enabled || false;
   const allowedFileExtensions = appStateContext?.state.frontendSettings?.allowed_file_extensions || "";
 
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    // Clear previous upload states
+    setUploadedFileId(null);
+    setUploadedFileName(null);
+    setBase64File(null);
+    setSelectedFile(null);
+    setFileName(null); // Clear displayed name from previous selection
+
     const file = event.target.files?.[0];
 
     if (file) {
@@ -35,49 +45,77 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
 
       if (!allowedExtensions.includes(fileExtension)) {
         alert(`File type not allowed. Please upload one of the following file types: ${allowedFileExtensions}`);
-        // Clear the file input
-        event.target.value = "";
-        setFileName(null);
-        setBase64File(null);
-        setSelectedFile(null);
+        event.target.value = ""; // Clear the file input
         return;
       }
-      setSelectedFile(file);
-      setFileName(file.name);
-      await convertToBase64(file);
-    }
-  };
 
-  const convertToBase64 = async (file: Blob) => {
-    try {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setBase64File(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    } catch (error) {
-      console.error('Error:', error);
+      setSelectedFile(file); // Store the selected file object
+      setFileName(file.name); // For immediate UI feedback
+
+      setIsUploading(true);
+      const formData = new FormData();
+      formData.append("file", file);
+
+      try {
+        const response = await fetch("/api/upload_azure_openai_file", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (response.ok) {
+          const result = await response.json();
+          setUploadedFileId(result.file_id);
+          setUploadedFileName(result.filename);
+          setFileName(result.filename); // Update displayed name to the one confirmed by backend
+          setBase64File(null); // Clear base64 preview if file is uploaded via ID
+        } else {
+          const errorResult = await response.text();
+          console.error("File upload failed:", errorResult);
+          alert("File upload failed: " + errorResult);
+          // Clear all file states on error
+          setUploadedFileId(null);
+          setUploadedFileName(null);
+          setFileName(null);
+          setSelectedFile(null);
+          setBase64File(null);
+          event.target.value = ""; // Clear the file input
+        }
+      } catch (error) {
+        console.error("File upload exception:", error);
+        alert("File upload failed: " + (error as Error).message);
+        // Clear all file states on exception
+        setUploadedFileId(null);
+        setUploadedFileName(null);
+        setFileName(null);
+        setSelectedFile(null);
+        setBase64File(null);
+        event.target.value = ""; // Clear the file input
+      } finally {
+        setIsUploading(false);
+      }
+    } else {
+        event.target.value = ""; // Clear the file input if no file was selected or selection was cancelled
     }
   };
 
   const sendQuestion = () => {
-    if (disabled || !question.trim()) {
+    if (disabled || !question.trim() || isUploading) { // Disable send if uploading
       return
     }
 
     let fileContentPart: { type: "image_url"; image_url: { url: string } } | { type: "file"; file: { url: string; name: string } } | null = null;
 
-    if (base64File && selectedFile && fileName) { // Ensure selectedFile and fileName are also checked
-      if (selectedFile.type.startsWith('image/')) {
-        fileContentPart = { type: "image_url", image_url: { url: base64File } };
-      } else {
-        fileContentPart = { type: "file", file: { url: base64File, name: fileName } };
-      }
+    // If a file has been uploaded and has an ID, use it.
+    if (uploadedFileId && uploadedFileName) {
+        // The API expects { type: "file", file: { file_id: string; name: string } }
+        // This will be used to construct the message content.
+        fileContentPart = { type: "file", file: { file_id: uploadedFileId, name: uploadedFileName } };
     }
+    // No more base64 image sending; all files are expected to be uploaded and referenced by ID.
 
-    const questionTextPart = { type: "text" as "text", text: question }; // Added "as text" for type consistency
+
+    const questionTextPart = { type: "text" as "text", text: question };
     const contentForRequest: ChatMessage["content"] = fileContentPart ? [questionTextPart, fileContentPart] : question.toString();
-
 
     if (conversationId) {
       onSend(contentForRequest, conversationId);
@@ -88,9 +126,17 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
     if (clearOnSend) {
       setQuestion('');
     }
+    // Clear all file related states
     setBase64File(null);
     setFileName(null);
     setSelectedFile(null);
+    setUploadedFileId(null);
+    setUploadedFileName(null);
+    // Reset the file input visually
+    const fileInput = document.getElementById('fileInput') as HTMLInputElement;
+    if (fileInput) {
+        fileInput.value = "";
+    }
   }
 
   const onEnterPress = (ev: React.KeyboardEvent<Element>) => {
@@ -104,7 +150,20 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
     setQuestion(newValue || '')
   }
 
-  const sendQuestionDisabled = disabled || !question.trim()
+  const sendQuestionDisabled = disabled || !question.trim() || isUploading
+
+  const clearUploadedFile = () => {
+    setUploadedFileId(null);
+    setUploadedFileName(null);
+    setFileName(null);
+    setSelectedFile(null);
+    setBase64File(null); // if used for previews
+    // Reset the file input visually
+    const fileInput = document.getElementById('fileInput') as HTMLInputElement;
+    if (fileInput) {
+        fileInput.value = "";
+    }
+  };
 
   return (
     <Stack horizontal className={styles.questionInputContainer}>
@@ -117,6 +176,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
         value={question}
         onChange={onQuestionChange}
         onKeyDown={onEnterPress}
+        disabled={isUploading} // Disable text field during upload
       />
       {!OYD_ENABLED && (
         <div className={styles.fileInputContainer}>
@@ -126,6 +186,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
             onChange={(event) => handleFileUpload(event)}
             accept={allowedFileExtensions}
             className={styles.fileInput}
+            disabled={isUploading} // Disable file input during upload
           />
           <label htmlFor="fileInput" className={styles.fileLabel} aria-label='Upload File'>
             <FontIcon
@@ -135,7 +196,21 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
             />
           </label>
         </div>)}
-      {fileName && <p className={styles.uploadedFile}>{fileName}</p>}
+      {isUploading && <div className={styles.uploadingMessage}>Uploading...</div>}
+      {!isUploading && uploadedFileName && (
+        <div className={styles.uploadedFileDisplay}>
+          Attached: {uploadedFileName} 
+          <button onClick={clearUploadedFile} className={styles.clearFileButton}>X</button>
+        </div>
+      )}
+      {/* Display for base64 image preview if that logic is kept separate and base64File is populated */}
+      {/* {!isUploading && !uploadedFileName && base64File && selectedFile?.type.startsWith('image/') && (
+        <div className={styles.uploadedFileDisplay}>
+          <img src={base64File} alt="Preview" style={{ maxWidth: '50px', maxHeight: '50px' }} />
+          {fileName}
+          <button onClick={clearUploadedFile} className={styles.clearFileButton}>X</button>
+        </div>
+      )} */}
       <div
         className={styles.questionInputSendButtonContainer}
         role="button"

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -194,7 +194,9 @@ const Chat = () => {
       if (secondPart.type === "image_url") {
         questionContent = [firstPart, { type: "image_url", image_url: { url: secondPart.image_url.url } }];
       } else if (secondPart.type === "file") {
-        questionContent = [firstPart, { type: "file", file: { url: (secondPart as any).file.url, name: (secondPart as any).file.name } }];
+        // Ensure correct propagation of file_id and name
+        const fileData = secondPart.file; // secondPart is of type ChatMessageContentParts
+        questionContent = [firstPart, { type: "file", file: { file_id: fileData.file_id, name: fileData.name } }];
       } else {
         // Fallback or error handling if needed, though current types restrict to image_url or file
         questionContent = firstPart.text; 
@@ -336,7 +338,9 @@ const Chat = () => {
       if (secondPart.type === "image_url") {
         questionContentWithFile = [firstPart, { type: "image_url", image_url: { url: secondPart.image_url.url } }];
       } else if (secondPart.type === "file") {
-        questionContentWithFile = [firstPart, { type: "file", file: { url: (secondPart as any).file.url, name: (secondPart as any).file.name } }];
+        // Ensure correct propagation of file_id and name
+        const fileData = secondPart.file; // secondPart is of type ChatMessageContentParts
+        questionContentWithFile = [firstPart, { type: "file", file: { file_id: fileData.file_id, name: fileData.name } }];
       } else {
         // Fallback or error handling if needed
         questionContentWithFile = firstPart.text;


### PR DESCRIPTION
This commit refactors the file upload functionality to align with the Azure OpenAI Assistants API, which requires a two-step process for attaching files to messages:

1.  Files are first uploaded to Azure OpenAI via a dedicated mechanism, which returns a `file_id`.
2.  Chat messages then reference this `file_id` to use the file.

Changes include:

-   **Backend (`app.py`):**
    -   Added a new endpoint `POST /api/upload_azure_openai_file`.
    -   This endpoint receives a file from the frontend, uploads it to
        Azure OpenAI using `client.files.create(..., purpose="assistants")`,
        and returns the `file_id` and `filename`.
    -   Includes error handling and logging for this new endpoint.

-   **Frontend (`QuestionInput.tsx`):**
    -   Modified `handleFileUpload` to send the selected file to the new
        `/api/upload_azure_openai_file` backend endpoint.
    -   Added state variables (`uploadedFileId`, `uploadedFileName`,
        `isUploading`) to manage the upload process and its result.
    -   Updated UI to show upload status and the name of the uploaded file,
        with an option to clear it.
    -   Modified `sendQuestion` to construct the message payload using
        `{ type: "file", file: { file_id: uploadedFileId, name: uploadedFileName } }`
        for all file attachments (including images, which now also use this
        `file_id` mechanism).

-   **TypeScript Definitions (`models.ts`):**
    -   Updated `ChatMessage.content` to expect the structure
        `{ type: "file", file: { file_id: string; name?: string; } }` for
        file attachments, replacing previous base64 or `file_url` approaches.
        Image attachments via `image_url` are kept for direct vision model
        chat completions but are not used by QuestionInput for assistant file uploads.

-   **Frontend (`Chat.tsx`):**
    -   Updated rendering logic to display "Attached file: [filename]" for
        messages with `type: "file"`, using `contentPart.file.name`.
    -   Ensured functions like `makeApiRequestWithoutCosmosDB` and
        `makeApiRequestWithCosmosDB` correctly handle and construct message
        parts with the `file_id` structure if they process such content.

-   **Dependencies:**
    -   Confirmed `openai` Python library version (`1.55.3`) is sufficient.

This change addresses previous API errors related to incorrect file payload structures (like `file_url` or missing `file_id`) when interacting with an Azure OpenAI service that expects `file_id` for file references in messages, particularly in an Assistants context.

### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
